### PR TITLE
Add device manifests for Waveshare ESP32 displays

### DIFF
--- a/boards/manifests/index.json
+++ b/boards/manifests/index.json
@@ -106,6 +106,20 @@
       "chip": "ESP32-S3",
       "vendor": "waveshare",
       "description": "ESP32-S3R8 with 1.64\" 280x456 AMOLED (CO5300), FT3168 touch, QMI8658 IMU, SD card"
+    },
+    {
+      "id": "waveshare_s3_amoled_1in8",
+      "name": "Waveshare ESP32-S3 Touch AMOLED 1.8",
+      "chip": "ESP32-S3",
+      "vendor": "waveshare",
+      "description": "ESP32-S3 N16R8 with 1.8\" 368x448 AMOLED, touch, dual mic, IMU, audio, SD, RTC"
+    },
+    {
+      "id": "waveshare_c3_lcd_1.47",
+      "name": "Waveshare ESP32-C3 LCD 1.47",
+      "chip": "ESP32-C3",
+      "vendor": "waveshare",
+      "description": "ESP32-C3FH4 with 1.47\" 172x320 IPS LCD, IO expander, SD card, battery charging"
     }
   ]
 }

--- a/boards/manifests/waveshare_c3_lcd_1.47.json
+++ b/boards/manifests/waveshare_c3_lcd_1.47.json
@@ -1,0 +1,89 @@
+{
+  "identity": {
+    "id": "waveshare_c3_lcd_1.47",
+    "name": "Waveshare ESP32-C3 LCD 1.47",
+    "vendor": "waveshare",
+    "chip": "ESP32-C3",
+    "revision": "1.0.0",
+    "description": "ESP32-C3FH4 with 1.47\" 172x320 IPS LCD, IO expander, SD card, battery charging"
+  },
+  "network": {
+    "mdns_enabled": true,
+    "ap_password": null,
+    "default_services": [
+      "http",
+      "webrepl"
+    ]
+  },
+  "capabilities": {
+    "wifi": true,
+    "bluetooth": true,
+    "neopixel": false,
+    "status_led": false,
+    "usb_otg": false,
+    "display": true,
+    "touch": false,
+    "sdcard": true,
+    "battery": true,
+    "gpio_expander": true
+  },
+  "resources": {
+    "pins": {
+      "boot": 9
+    },
+    "spi": {
+      "lcd": {
+        "sck": 7,
+        "mosi": 5,
+        "miso": 6,
+        "dc": 8
+      }
+    },
+    "i2c": {
+      "i2c0": {
+        "scl": 3,
+        "sda": 4
+      }
+    },
+    "uart": {
+      "primary": {
+        "tx": 21,
+        "rx": 20
+      }
+    }
+  },
+  "devices": {
+    "display": {
+      "type": "ST7789",
+      "driver": "st7789",
+      "bus": "spi.lcd",
+      "interface": "spi",
+      "width": 172,
+      "height": 320,
+      "offset_x": 34,
+      "offset_y": 0,
+      "color_bits": 16,
+      "backlight": {
+        "type": "io_expander_pwm",
+        "active_high": true,
+        "pwm_capable": true
+      },
+      "cs_expander_pin": 0,
+      "rst_expander_pin": 1,
+      "description": "1.47\" 172x320 IPS LCD (ST7789V2) with CS/RST via IO expander"
+    },
+    "gpio_expander": {
+      "type": "custom_mcu",
+      "bus": "i2c.i2c0",
+      "i2c_address": "0x24",
+      "pins_used": 3,
+      "description": "I2C IO expander for LCD CS, LCD RST, SD CS, and backlight PWM"
+    },
+    "sdcard": {
+      "mode": "SPI",
+      "bus": "spi.lcd",
+      "cs_expander_pin": 2,
+      "description": "TF/microSD card (SPI mode, CS via IO expander)"
+    }
+  }
+}

--- a/boards/manifests/waveshare_s3_amoled_1in8.json
+++ b/boards/manifests/waveshare_s3_amoled_1in8.json
@@ -1,0 +1,144 @@
+{
+  "identity": {
+    "id": "waveshare_s3_amoled_1in8",
+    "name": "Waveshare ESP32-S3 Touch AMOLED 1.8",
+    "vendor": "waveshare",
+    "chip": "ESP32-S3",
+    "revision": "1.0.0",
+    "description": "ESP32-S3 N16R8 with 1.8\" 368x448 AMOLED, touch, dual mic, IMU, audio, SD, RTC"
+  },
+  "network": {
+    "mdns_enabled": true,
+    "ap_password": null,
+    "default_services": [
+      "http",
+      "webrepl"
+    ]
+  },
+  "capabilities": {
+    "wifi": true,
+    "bluetooth": true,
+    "neopixel": false,
+    "status_led": false,
+    "usb_otg": true,
+    "display": true,
+    "touch": true,
+    "imu": true,
+    "audio": true,
+    "microphone": true,
+    "sdcard": true,
+    "rtc": true,
+    "battery": true,
+    "gnss": false,
+    "gpio_expander": false
+  },
+  "resources": {
+    "pins": {
+      "boot": 0
+    },
+    "qspi": {
+      "lcd": {
+        "sck": 11,
+        "data0": 4,
+        "data1": 5,
+        "data2": 6,
+        "data3": 7,
+        "cs": 12
+      }
+    },
+    "sdmmc": {
+      "sdcard": {
+        "clk": 2,
+        "cmd": 1,
+        "d0": 3,
+        "slot": 0
+      }
+    },
+    "i2c": {
+      "i2c0": {
+        "scl": 14,
+        "sda": 15
+      }
+    },
+    "i2s": {
+      "audio": {
+        "mclk": 16,
+        "bck": 9,
+        "ws": 45,
+        "din": 10,
+        "dout": 8
+      }
+    },
+    "uart": {
+      "primary": {
+        "tx": 43,
+        "rx": 44
+      }
+    },
+    "usb": {
+      "dm": 19,
+      "dp": 20
+    },
+    "gpio": {
+      "tp_int": 21,
+      "pa_enable": 46
+    }
+  },
+  "devices": {
+    "display": {
+      "type": "SH8601",
+      "driver": "sh8601",
+      "bus": "qspi.lcd",
+      "width": 368,
+      "height": 448,
+      "offset_x": 0,
+      "offset_y": 0,
+      "interface": "qspi",
+      "color_bits": 16,
+      "description": "1.8\" 368x448 AMOLED (SH8601) with QSPI interface"
+    },
+    "touch": {
+      "type": "FT3168",
+      "driver": "ft3168",
+      "bus": "i2c.i2c0",
+      "i2c_address": "0x38",
+      "int_pin": 21,
+      "description": "Capacitive touch controller (FT3168)"
+    },
+    "imu": {
+      "type": "QMI8658C",
+      "driver": "qmi8658",
+      "bus": "i2c.i2c0",
+      "i2c_address": "0x6B",
+      "description": "6-axis accelerometer/gyroscope"
+    },
+    "rtc": {
+      "type": "PCF85063",
+      "driver": "pcf85063",
+      "bus": "i2c.i2c0",
+      "i2c_address": "0x51",
+      "description": "Real-time clock with alarm and interrupt"
+    },
+    "audio_codec": {
+      "type": "ES8311",
+      "driver": "es8311",
+      "bus": "i2c.i2c0",
+      "i2c_address": "0x18",
+      "i2s_bus": "i2s.audio",
+      "pa_pin": 46,
+      "description": "Audio codec for speaker output (DAC)"
+    },
+    "pmu": {
+      "type": "AXP2101",
+      "driver": "axp2101",
+      "bus": "i2c.i2c0",
+      "i2c_address": "0x34",
+      "description": "Power management unit — battery charging, voltage regulation"
+    },
+    "sdcard": {
+      "mode": "SDMMC",
+      "bus": "sdmmc.sdcard",
+      "description": "TF/microSD card (1-bit SDMMC mode)"
+    }
+  }
+}


### PR DESCRIPTION
This pull request adds support for two new Waveshare boards by updating the board manifest index and introducing detailed manifest files for each new board. The changes ensure that the firmware can correctly identify and utilize the hardware capabilities of these boards.

**New board support:**

* Added entries for [`waveshare_s3_amoled_1in8`](https://docs.waveshare.com/ESP32-S3-Touch-AMOLED-1.8) and [`waveshare_c3_lcd_1.47`](https://docs.waveshare.com/ESP32-C3-LCD-1.47) to the main manifest index (`index.json`), including their basic identification and descriptions.

**Board manifest files:**

* Added a new manifest file for `waveshare_s3_amoled_1in8`, detailing its hardware resources (display, touch, IMU, RTC, audio, PMU, SD card), pin mappings, and device configuration.
* Added a new manifest file for `waveshare_c3_lcd_1.47`, specifying its display, IO expander, SD card, pin assignments, and hardware capabilities.